### PR TITLE
add (and default to on) --preview

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// BenchmarkDummy does not measure anything meaningful, but is helpful for
+// quickly iterating on UI changes to `benchdiff`, for example with the
+// following invocation: go run . --old HEAD . -r '.' -d 50ms -c 25
+func BenchmarkDummy(b *testing.B) {
+	b.ReportAllocs()
+	var cnt int
+	for i := 0; i < b.N; i++ {
+		sl := make([]int, 1024)
+		sl[0], sl[1] = 1, int(time.Now().UnixNano())
+		for j := 2; j < len(sl); j++ {
+			sl[j] = sl[j-1]*sl[j-2] + 1
+		}
+		cnt += sl[len(sl)-1]
+	}
+}

--- a/main.go
+++ b/main.go
@@ -350,7 +350,7 @@ func runCmpBenches(
 			pkgFrac := ui.Fraction(i+1, len(tests))
 			iterFrac := ui.Fraction(j+1, itersPerTest)
 			var buf bytes.Buffer
-			if preview {
+			if preview && j > 0 {
 				_, err := processBenchOutput(ctx, &buf, bs1, bs2, true, text, tests, nil)
 				if err != nil {
 					return err

--- a/main.go
+++ b/main.go
@@ -593,7 +593,7 @@ func (bs *benchSuite) build(pkgFilter []string, postChck string, t time.Time) (e
 	}
 
 	var spinner ui.Spinner
-	spinner.Start(os.Stderr, fmt.Sprintf("building benchmark binaries for %s: %.50s [bazel=%t]", bs.ref,
+	spinner.Start(os.Stderr, fmt.Sprintf("building benchmark binaries for %s: %.50s [bazel=%t] ", bs.ref,
 		bs.subject, bs.useBazel))
 	defer spinner.Stop()
 	for i, pkg := range pkgs {

--- a/ui/spinner.go
+++ b/ui/spinner.go
@@ -46,7 +46,7 @@ func (s *Spinner) Start(out io.Writer, prefix string) {
 			}
 			fmt.Fprint(&s.w, prefix)
 			if progress != "" {
-				fmt.Fprintf(&s.w, " %s", progress)
+				fmt.Fprint(&s.w, progress)
 			}
 			fmt.Fprintf(&s.w, " %s\n", spinnerChars[spinnerIdx%len(spinnerChars)])
 			if err := s.w.Flush(out); err != nil {


### PR DESCRIPTION
  
![demo](https://github.com/user-attachments/assets/7496b809-806a-451d-9af2-98acfecdbc2c)

  With this flag, the benchdiff output is rendered between each
  interleaved run of both the old and new benches (within the current
  package).
  
  Especially for longer benchmark runs, this is helpful to give an idea
  of what the results are likely going to be. In some cases, this may
  prompt the user to call it early, thus saving time. But it's also
  pleasant to be able to just check in, which is my primary motivation
  for this change.



  