### PR TITLE
Merge profiles

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/nvanbenschoten/benchdiff
 go 1.13
 
 require (
+	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/perf v0.0.0-20250106172127-400946f43c82

--- a/go.sum
+++ b/go.sum
@@ -761,6 +761,7 @@ github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/s2a-go v0.1.0/go.mod h1:OJpEgntRZo8ugHpF9hkoLJbS5dSI20XZeXJ9JVywLlM=


### PR DESCRIPTION
Previously, `--{mem,cpu,mutex}profile` would instruct each iteration of the benchmark to write the profile to the same file, leaving only the last iteration's output in place.

This commit instead clears all output profiles before the first run, and then merges all consecutive profiles into each other. This means that it is now meaningful to combine `--count` and `--{mem,cpu,mutex}profile`; one will get a result and a set of profiles that exactly corresponds to the result.

The previous workflow was to run an extra invocation with `--count=1` at the end to collect profiles, but then the new/old profiles would not compare as well since they hadn't been smoothed out over multiple runs.

Now, when profiling flags are passed, differences and profiles correspond to each other, which I've wished for several times in the past.