### PR TITLE
Bazel runfiles

### DIFF
--- a/bench.go
+++ b/bench.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"hash/fnv"
 	"os"
 	"path/filepath"
@@ -9,6 +10,13 @@ import (
 
 	"github.com/pkg/errors"
 )
+
+const bazelRunScript = `#!/bin/bash
+SCRIPT_PATH="$(realpath "$0")"
+BAZEL_DIR="${SCRIPT_PATH}.bazel"
+RUNFILES_DIR="${BAZEL_DIR}/%[1]s.runfiles"
+"${BAZEL_DIR}/%[1]s" "$@"
+`
 
 // expandPackages expands the package filter into all of the packages that it
 // references using `go list`.
@@ -65,40 +73,80 @@ func testBinToPkg(bin string) string {
 	return strings.ReplaceAll(bin, "_", "/")
 }
 
-// buildTestBin builds a test binary for the specified package and moves it to
-// the destination directory if successful.
-func buildTestBin(pkg, dst string, useBazel bool) (string, bool, error) {
+// buildTestBinWithGo builds a test binary, using Go directly, for the specified
+// package and moves it to the destination directory if successful.
+func buildTestBinWithGo(pkg, dst string) (string, bool, error) {
 	dstFile := pkgToTestBin(pkg) // cockroachdb_cockroach_pkg_util_log
-	var srcFile string
-	if !useBazel {
-		srcFile = dstFile
-		// Capture to silence warnings from pkgs with no test files.
-		if _, err := capture("go", "test", "-c", "-o", dstFile, pkg); err != nil {
-			return "", false, errors.Wrap(err, "building test binary")
-		}
-	} else {
-		relPkg := strings.TrimPrefix(pkg, "github.com/cockroachdb/cockroach/")
-		pathList := strings.Split(relPkg, string(filepath.Separator)) // ['pkg','util','log']
-		last := pathList[len(pathList)-1]                             // 'log'
-		// `bazel build //pkg/util/log:log_test`.
-		if _, err := capture("bazel", "build", "//"+relPkg+":"+last+"_test"); err != nil {
-			return "", false, errors.Wrap(err, "building test binary")
-		}
-		// `_bazel/bin/pkg/util/log/log_test_/log_test`.
-		out := append([]string{"_bazel", "bin"}, pathList...)
-		out = append(out, last+"_test_", last+"_test")
-		srcFile = filepath.Join(out...)
+	// Capture to silence warnings from pkgs with no test files.
+	if _, err := capture("go", "test", "-c", "-o", dstFile, pkg); err != nil {
+		return "", false, errors.Wrap(err, "building test binary")
 	}
 
 	// If there were no tests in the package, no file will have been created.
-	if _, err := os.Stat(srcFile); err != nil {
+	if _, err := os.Stat(dstFile); err != nil {
 		if os.IsNotExist(err) {
 			return "", false, nil
 		}
 		return "", false, errors.Wrap(err, "looking for test binary")
 	}
-	if err := spawn("mv", srcFile, filepath.Join(dst, dstFile)); err != nil {
+	if err := spawn("mv", dstFile, filepath.Join(dst, dstFile)); err != nil {
 		return "", false, errors.Wrap(err, "moving test binary")
 	}
 	return dstFile, true, nil
+}
+
+// buildTestBinWithBazel builds a test binary, using Bazel, for the specified
+// package. It creates an executable script inplace of a binary that will invoke
+// the test binary with the correct runfiles, stored in a `<dst>.bazel`
+// directory alongside it.
+func buildTestBinWithBazel(pkg, dst string) (string, bool, error) {
+	dstBin := pkgToTestBin(pkg) // cockroachdb_cockroach_pkg_util_log
+	dstBazelDir := filepath.Join(dst, dstBin+".bazel")
+
+	relPkg := strings.TrimPrefix(pkg, "github.com/cockroachdb/cockroach/")
+	pathList := strings.Split(relPkg, string(filepath.Separator)) // ['pkg','util','log']
+	last := pathList[len(pathList)-1]                             // 'log'
+	// `bazel build //pkg/util/log:log_test`.
+	if _, err := capture("bazel", "build", "//"+relPkg+":"+last+"_test"); err != nil {
+		return "", false, errors.Wrap(err, "building test binary")
+	}
+
+	// `_bazel/bin/pkg/util/log/log_test_`.
+	outDir := append([]string{"_bazel", "bin"}, pathList...)
+	outDir = append(outDir, last+"_test_")
+
+	// `_bazel/bin/pkg/util/log/log_test_/log_test`.
+	srcBin := filepath.Join(filepath.Join(outDir...), last+"_test")
+	// `_bazel/bin/pkg/util/log/log_test_/log_test.runfiles`.
+	srcRunfilesDir := filepath.Join(filepath.Join(outDir...), filepath.Base(srcBin)+".runfiles")
+
+	// If there were no tests in the package, no test binary file will have been
+	// created.
+	if _, err := os.Stat(srcBin); err != nil {
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		return "", false, errors.Wrap(err, "looking for test binary")
+	}
+	if err := os.Mkdir(dstBazelDir, 0755); err != nil {
+		return "", false, errors.Wrap(err, "creating bazel binary directory")
+	}
+	if err := spawn("cp", "-rL", srcBin, srcRunfilesDir, dstBazelDir); err != nil {
+		return "", false, errors.Wrap(err, "copying binary and bazel runfiles")
+	}
+	runScript := fmt.Sprintf(bazelRunScript, filepath.Base(srcBin))
+	if err := writeExecutableScript(runScript, filepath.Join(dst, dstBin)); err != nil {
+		return "", false, errors.Wrap(err, "writing bazel binary script")
+	}
+	return dstBin, true, nil
+}
+
+func writeExecutableScript(script, path string) error {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	_, err = file.WriteString(script)
+	return err
 }


### PR DESCRIPTION
Previously, functionality to build binaries with Bazel was added, but did not yet consider packages that contain Bazel runfiles. These are usually defined in the Bazel build file using the data field on Bazel test targets. Even if a benchmark does not use these runfiles, the binary will still not function if the runfiles are not present.

This change adds support for Bazel runfiles. It requires copying runfiles from bazel outputs and also setting the `RUNFILES_DIR` env var before executing a test binary. To achieve this the primary test binary now becomes a script that invokes the actual test binary under a designated `<bin>.bazel` directory for each test output.

```
└── bin
    └── 1058449141
        ├── cockroachdb_cockroach_pkg_sql_tests
        └── cockroachdb_cockroach_pkg_sql_tests.bazel
            ├── tests_test
            └── tests_test.runfiles
                ├── MANIFEST
```

 `cockroachdb_cockroach_pkg_sql_tests` is a script that invokes the actual
 binaries with runfiles env configured:

```bash
#!/bin/bash
SCRIPT_PATH="$(realpath "$0")"
BAZEL_DIR="${SCRIPT_PATH}.bazel"
export RUNFILES_DIR="${BAZEL_DIR}/tests_test.runfiles"
"${BAZEL_DIR}/tests_test" "$@"
```