### PR TITLE
fix preview to only erase one line for the spinner

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -14,14 +15,20 @@ import (
 // quickly iterating on UI changes to `benchdiff`, for example with the
 // following invocation: go run . --old HEAD . -r '.' -d 50ms -c 25
 func BenchmarkDummy(b *testing.B) {
-	b.ReportAllocs()
-	var cnt int
-	for i := 0; i < b.N; i++ {
-		sl := make([]int, 1024)
-		sl[0], sl[1] = 1, int(time.Now().UnixNano())
-		for j := 2; j < len(sl); j++ {
-			sl[j] = sl[j-1]*sl[j-2] + 1
-		}
-		cnt += sl[len(sl)-1]
+	const numBenchmarks = 10
+
+	for n := 0; n < numBenchmarks; n++ {
+		b.Run(fmt.Sprintf("%02d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			var cnt int
+			for i := 0; i < b.N; i++ {
+				sl := make([]int, 1024)
+				sl[0], sl[1] = 1, int(time.Now().UnixNano())
+				for j := 2; j < len(sl); j++ {
+					sl[j] = sl[j-1]*sl[j-2] + 1
+				}
+				cnt += sl[len(sl)-1]
+			}
+		})
 	}
 }

--- a/ui/spinner_test.go
+++ b/ui/spinner_test.go
@@ -1,0 +1,22 @@
+package ui
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestSpinner(t *testing.T) {
+	if !testing.Verbose() {
+		// This is a visual test that can only be run in verbose mode.
+		return
+	}
+	w := NewWriter(os.Stdout)
+	s := StartSpinner(w, "prefix")
+	for i := 1; i <= 4; i++ {
+		time.Sleep(1 * time.Second)
+		s.Update(fmt.Sprintf(" %ds", i))
+	}
+	s.Stop()
+}

--- a/ui/writer_test.go
+++ b/ui/writer_test.go
@@ -1,0 +1,42 @@
+package ui
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestWriter(t *testing.T) {
+	if !testing.Verbose() {
+		// This is a visual test that can only be run in verbose mode.
+		return
+	}
+	w := NewWriter(os.Stdout)
+	fmt.Fprintf(w, "line 1\n")
+	fmt.Fprintf(w, "line 2\n")
+	m1 := w.GetMark()
+	fmt.Fprintf(w, "line 3\n")
+	fmt.Fprintf(w, "line 4\n")
+	for i := 0; i < 4; i++ {
+		time.Sleep(1 * time.Second)
+		w.ClearToMark(m1)
+		k := rand.IntN(5)
+		for j := 0; j <= k; j++ {
+			fmt.Fprintf(w, "line %d-%d\n", i, j)
+		}
+	}
+	w.ClearToMark(m1)
+	fmt.Fprintf(w, "line 3\n")
+	fmt.Fprintf(w, "line 4\n")
+	m2 := w.GetMark()
+	fmt.Fprintf(w, "line 5\n")
+	fmt.Fprintf(w, "line 6\n")
+	time.Sleep(2 * time.Second)
+	w.ClearToMark(m2)
+	fmt.Fprintf(w, "line 5b\n")
+	time.Sleep(2 * time.Second)
+	w.ClearToMark(m1)
+	fmt.Fprintf(w, "done\n")
+}


### PR DESCRIPTION
#### multiple dummy benchmarks

The `numBenchmarks` constant can be increased to test the preview mode
when there are a lot of benchmarks (more than fit on one screen).

#### fix preview to only erase one line for the spinner

Before this change, every 100ms we erase and reprint all preview
lines. This is very bad when the preview doesn't fit the screen, and
it's also problematic when ran via ssh.

We fix this by redesigning `ui.Writer`. It now provides the ability to
obtain "marks" and then clear back lines up to a specific mark. The
preview and the spinner use separate marks.