### PR TITLE
Force GODEBUG=runtimecontentionstacks=1

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -54,6 +54,17 @@ func spawnWith(in io.Reader, out, err io.Writer, args ...string) error {
 	} else {
 		cmd = exec.Command(args[0], args[1:]...)
 	}
+
+	// Ensure that GODEBUG=[...,]runtimecontentionstacks=1 is set to improve
+	// mutex profiles.
+	env := os.Environ()
+	envGodebug := os.Getenv("GODEBUG")
+	if envGodebug != "" {
+		envGodebug += ","
+	}
+	envGodebug += "runtimecontentionstacks=1"
+	cmd.Env = append(env, "GODEBUG="+envGodebug)
+
 	cmd.Stdin = in
 	cmd.Stdout = out
 	cmd.Stderr = err


### PR DESCRIPTION
I verified that this works using

```
go run . --old HEAD . -r '.' -d 50ms -c 5 --mutexprofile
```

and looking at the mutex profile (which primarily shows runtime-internal
contention since there isn't a single mutex in the benchmark).
