### PR TITLE
Improve profile merging even when "extra" profiles are created

### DIFF
--- a/main.go
+++ b/main.go
@@ -599,18 +599,33 @@ func processBenchOutput(
 func logProfileLocations(
 	bs1, bs2 *benchSuite, cpuProfile, memProfile, mutexProfile bool,
 ) {
-	log := func(label, filename string) {
+	if !cpuProfile && !memProfile && !mutexProfile {
+		return
+	}
+	entries, err := os.ReadDir(bs1.profileMergedDir())
+	if err != nil {
+		return
+	}
+	var names []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		label := name
+		switch name {
+		case cpuProfileName:
+			label = "cpu"
+		case memProfileName:
+			label = "mem"
+		case mutexProfileName:
+			label = "mutex"
+		}
 		fmt.Printf("\nwrote merged %s profile to:\n  old=%s\n  new=%s\n",
-			label, bs1.profileMergedPath(filename), bs2.profileMergedPath(filename))
-	}
-	if cpuProfile {
-		log("cpu", cpuProfileName)
-	}
-	if memProfile {
-		log("mem", memProfileName)
-	}
-	if mutexProfile {
-		log("mutex", mutexProfileName)
+			label, bs1.profileMergedPath(name), bs2.profileMergedPath(name))
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/fs"
 	"io/ioutil"
 	"math"
 	"os"
@@ -405,39 +404,39 @@ func runCmpBenches(
 }
 
 func (bs *benchSuite) unlinkProfiles() error {
-	return filepath.WalkDir(bs.artDir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() || !strings.HasSuffix(d.Name(), ".prof") {
-			return nil
-		}
-		if err := os.Remove(d.Name()); err != nil && !os.IsNotExist(err) {
-			return err
-		}
-		return nil
-	})
+	if err := bs.ensureProfileDirs(); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(bs.profileRunDir()); err != nil {
+		return err
+	}
+	return os.MkdirAll(bs.profileRunDir(), 0744)
 }
 
 func (bs *benchSuite) mergeProfiles(cpuProfile, memProfile, mutexProfile bool) error {
-	type tup struct {
-		from, into string
+	if !cpuProfile && !memProfile && !mutexProfile {
+		return nil
 	}
-	var tups []tup
-	if cpuProfile {
-		tups = append(tups, tup{"cpu_last", "cpu"})
+	if err := bs.ensureProfileDirs(); err != nil {
+		return err
 	}
-	if memProfile {
-		tups = append(tups, tup{"mem_last", "mem"})
+	entries, err := os.ReadDir(bs.profileRunDir())
+	if err != nil {
+		return err
 	}
-	if mutexProfile {
-		tups = append(tups, tup{"mutex_last", "mutex"})
+	if len(entries) == 0 {
+		return errors.New("no profile files created by benchmark run")
 	}
-	for _, cur := range tups {
-		dest := bs.getProfileFile(cur.into)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		srcPath := filepath.Join(bs.profileRunDir(), name)
+		destPath := filepath.Join(bs.profileMergedDir(), name)
 		var srcs []*profile.Profile
-		if _, err := os.Stat(dest); err == nil {
-			mergedBytes, err := os.ReadFile(dest)
+		if _, err := os.Stat(destPath); err == nil {
+			mergedBytes, err := os.ReadFile(destPath)
 			if err != nil {
 				return err
 			}
@@ -446,24 +445,23 @@ func (bs *benchSuite) mergeProfiles(cpuProfile, memProfile, mutexProfile bool) e
 				return err
 			}
 			srcs = append(srcs, p)
+		} else if !os.IsNotExist(err) {
+			return err
 		}
-		{
-			newBytes, err := os.ReadFile(bs.getProfileFile(cur.from))
-			if err != nil {
-				return err
-			}
-			p, err := profile.Parse(bytes.NewReader(newBytes))
-			if err != nil {
-				return err
-			}
-			srcs = append(srcs, p)
+		newBytes, err := os.ReadFile(srcPath)
+		if err != nil {
+			return err
 		}
-
+		p, err := profile.Parse(bytes.NewReader(newBytes))
+		if err != nil {
+			return err
+		}
+		srcs = append(srcs, p)
 		merged, err := profile.Merge(srcs)
 		if err != nil {
 			return err
 		}
-		f, err := os.Create(dest)
+		f, err := os.Create(destPath)
 		if err != nil {
 			return err
 		}
@@ -495,14 +493,14 @@ func (bs *benchSuite) buildBenchArgs(
 		args = append(args, "-test.benchtime", benchTime)
 	}
 	if cpuProfile {
-		args = append(args, "-test.cpuprofile", bs.getProfileFile("cpu_last"))
+		args = append(args, "-test.cpuprofile", bs.profileRunPath(cpuProfileName))
 	}
 	if memProfile {
 		// TODO(nvanbenschoten): consider passing -test.memprofilerate=1.
-		args = append(args, "-test.memprofile", bs.getProfileFile("mem_last"))
+		args = append(args, "-test.memprofile", bs.profileRunPath(memProfileName))
 	}
 	if mutexProfile {
-		args = append(args, "-test.mutexprofile", bs.getProfileFile("mutex_last"))
+		args = append(args, "-test.mutexprofile", bs.profileRunPath(mutexProfileName))
 	}
 	if hasLogToStderr {
 		args = append(args, "--logtostderr", "NONE")
@@ -601,18 +599,18 @@ func processBenchOutput(
 func logProfileLocations(
 	bs1, bs2 *benchSuite, cpuProfile, memProfile, mutexProfile bool,
 ) {
-	log := func(profType string) {
+	log := func(label, filename string) {
 		fmt.Printf("\nwrote merged %s profile to:\n  old=%s\n  new=%s\n",
-			profType, bs1.getProfileFile(profType), bs2.getProfileFile(profType))
+			label, bs1.profileMergedPath(filename), bs2.profileMergedPath(filename))
 	}
 	if cpuProfile {
-		log("cpu")
+		log("cpu", cpuProfileName)
 	}
 	if memProfile {
-		log("mem")
+		log("mem", memProfileName)
 	}
 	if mutexProfile {
-		log("mutex")
+		log("mutex", mutexProfileName)
 	}
 }
 
@@ -646,6 +644,12 @@ type benchSuite struct {
 }
 type fileSet map[string]struct{}
 
+const (
+	cpuProfileName   = "cpu.prof"
+	memProfileName   = "mem.pb.gz"
+	mutexProfileName = "mutex.prof"
+)
+
 func makeBenchSuite(ref string, subject string, useBazel bool) benchSuite {
 	return benchSuite{
 		ref:       ref,
@@ -663,6 +667,9 @@ func (bs *benchSuite) build(pkgFilter []string, postChck string, t time.Time) (e
 	// Create the artifacts directory: ./benchdiff/<ref>/artifacts
 	bs.artDir = testArtifactsDir(bs.ref)
 	if err = os.MkdirAll(bs.artDir, 0744); err != nil {
+		return err
+	}
+	if err = bs.ensureProfileDirs(); err != nil {
 		return err
 	}
 
@@ -748,8 +755,31 @@ func (bs *benchSuite) getRunFile(t time.Time) string {
 	return filepath.Join(bs.artDir, "run."+t.Format(timeFormat))
 }
 
-func (bs *benchSuite) getProfileFile(profType string) string {
-	return filepath.Join(bs.artDir, profType+".prof")
+func (bs *benchSuite) profilesDir() string {
+	return filepath.Join(bs.artDir, "profiles")
+}
+
+func (bs *benchSuite) profileRunDir() string {
+	return filepath.Join(bs.profilesDir(), "run")
+}
+
+func (bs *benchSuite) profileMergedDir() string {
+	return filepath.Join(bs.profilesDir(), "merged")
+}
+
+func (bs *benchSuite) profileRunPath(name string) string {
+	return filepath.Join(bs.profileRunDir(), name)
+}
+
+func (bs *benchSuite) profileMergedPath(name string) string {
+	return filepath.Join(bs.profileMergedDir(), name)
+}
+
+func (bs *benchSuite) ensureProfileDirs() error {
+	if err := os.MkdirAll(bs.profileRunDir(), 0744); err != nil {
+		return err
+	}
+	return os.MkdirAll(bs.profileMergedDir(), 0744)
 }
 
 func (bs *benchSuite) getTestBinary(bin string) string {

--- a/main.go
+++ b/main.go
@@ -347,6 +347,15 @@ func runCmpBenches(
 	for i, t := range tests {
 		pkg := testBinToPkg(t)
 		m := w.GetMark()
+
+		// Log the command invocation once per test for each suite.
+		for _, b := range []*benchSuite{bs1, bs2} {
+			args := b.buildBenchArgs(t, runPattern, benchTime, cpuProfile, memProfile, mutexProfile)
+			if err := logRunCommand(b.getRunFile(b.timestamp), args); err != nil {
+				return errors.Wrap(err, "logging run command")
+			}
+		}
+
 		for j := 0; j < itersPerTest; j++ {
 			err := func() error {
 				w.ClearToMark(m)
@@ -377,7 +386,7 @@ func runCmpBenches(
 				// with a time correlation.
 				for _, b := range []*benchSuite{bs1, bs2} {
 					spinner.Update(" " + b.ref)
-					if err := runSingleBench(b, t, runPattern, benchTime, cpuProfile, memProfile, mutexProfile); err != nil {
+					if err := b.runSingleBench(t, runPattern, benchTime, cpuProfile, memProfile, mutexProfile); err != nil {
 						return err
 					}
 					if err := b.mergeProfiles(cpuProfile, memProfile, mutexProfile); err != nil {
@@ -469,9 +478,9 @@ func (bs *benchSuite) mergeProfiles(cpuProfile, memProfile, mutexProfile bool) e
 	return nil
 }
 
-func runSingleBench(
-	bs *benchSuite, test, runPattern, benchTime string, cpuProfile, memProfile, mutexProfile bool,
-) error {
+func (bs *benchSuite) buildBenchArgs(
+	test, runPattern, benchTime string, cpuProfile, memProfile, mutexProfile bool,
+) []string {
 	bin := bs.getTestBinary(test)
 
 	// Determine whether the binary has a --logtostderr flag. Use CombinedOutput
@@ -481,7 +490,6 @@ func runSingleBench(
 	out, _ := cmd.CombinedOutput()
 	hasLogToStderr := bytes.Contains(out, []byte("logtostderr"))
 
-	// Run the benchmark binary.
 	args := []string{bin, "-test.run", "-", "-test.bench", runPattern, "-test.benchmem"}
 	if benchTime != "" {
 		args = append(args, "-test.benchtime", benchTime)
@@ -499,6 +507,13 @@ func runSingleBench(
 	if hasLogToStderr {
 		args = append(args, "--logtostderr", "NONE")
 	}
+	return args
+}
+
+func (bs *benchSuite) runSingleBench(
+	test, runPattern, benchTime string, cpuProfile, memProfile, mutexProfile bool,
+) error {
+	args := bs.buildBenchArgs(test, runPattern, benchTime, cpuProfile, memProfile, mutexProfile)
 	if err := spawnWith(os.Stdin, bs.outFile, bs.outFile, args...); err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			if exitErr.ExitCode() == 1 {
@@ -512,6 +527,16 @@ func runSingleBench(
 		}
 	}
 	return nil
+}
+
+// logRunCommand appends the command invocation to the run file.
+func logRunCommand(path string, args []string) error {
+	// Build the command as a single line with quoted arguments.
+	quoted := make([]string, len(args))
+	for i, arg := range args {
+		quoted[i] = strconv.Quote(arg)
+	}
+	return os.WriteFile(path, []byte(strings.Join(quoted, " ")+"\n"), 0644)
 }
 
 func processBenchOutput(
@@ -613,6 +638,7 @@ type benchSuite struct {
 	ref       string
 	subject   string // commit subject
 	artDir    string
+	timestamp time.Time
 	outFile   *os.File
 	binDir    string
 	useBazel  bool
@@ -641,6 +667,7 @@ func (bs *benchSuite) build(pkgFilter []string, postChck string, t time.Time) (e
 	}
 
 	// Create output file: ./benchdiff/<ref>/artifacts/out.<time>
+	bs.timestamp = t
 	outFileName := bs.getOutputFile(t)
 	bs.outFile, err = os.OpenFile(outFileName, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
@@ -715,6 +742,10 @@ func (bs *benchSuite) close() {
 
 func (bs *benchSuite) getOutputFile(t time.Time) string {
 	return filepath.Join(bs.artDir, "out."+t.Format(timeFormat))
+}
+
+func (bs *benchSuite) getRunFile(t time.Time) string {
+	return filepath.Join(bs.artDir, "run."+t.Format(timeFormat))
 }
 
 func (bs *benchSuite) getProfileFile(profType string) string {

--- a/profiles_test.go
+++ b/profiles_test.go
@@ -1,0 +1,67 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/pprof/profile"
+)
+
+func TestMergeProfilesByName(t *testing.T) {
+	dir := t.TempDir()
+	bs := benchSuite{artDir: dir}
+	if err := bs.ensureProfileDirs(); err != nil {
+		t.Fatalf("ensure profile dirs: %v", err)
+	}
+	runMem := bs.profileRunPath(memProfileName)
+	runExtra := bs.profileRunPath("mem_BenchmarkFoo.pb.gz")
+	mergedMem := bs.profileMergedPath(memProfileName)
+	mergedExtra := bs.profileMergedPath("mem_BenchmarkFoo.pb.gz")
+
+	if err := writeTestProfile(runMem, 1); err != nil {
+		t.Fatalf("write run mem profile: %v", err)
+	}
+	if err := writeTestProfile(runExtra, 2); err != nil {
+		t.Fatalf("write run extra profile: %v", err)
+	}
+	if err := writeTestProfile(mergedMem, 3); err != nil {
+		t.Fatalf("write merged mem profile: %v", err)
+	}
+
+	if err := bs.mergeProfiles(false, true, false); err != nil {
+		t.Fatalf("merge profiles: %v", err)
+	}
+	if _, err := os.Stat(mergedMem); err != nil {
+		t.Fatalf("expected merged mem profile: %v", err)
+	}
+	if _, err := os.Stat(mergedExtra); err != nil {
+		t.Fatalf("expected merged extra profile: %v", err)
+	}
+}
+
+func writeTestProfile(path string, value int64) error {
+	p := &profile.Profile{
+		TimeNanos:     1,
+		DurationNanos: 1,
+		SampleType: []*profile.ValueType{
+			{Type: "alloc_objects", Unit: "count"},
+		},
+		Sample: []*profile.Sample{
+			{Value: []int64{value}},
+		},
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	if err := p.Write(f); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}


### PR DESCRIPTION
This improves the use of `benchdiff` with CockroachDB benchmarks like `BenchmarkSysbench` which create extra profiles when used with `-memprofile`. Concretely, instead of only (say) `foo.pb.gz`, the benchmark will also create an additional profile (say) `foo_BenchmarkSysbench_KV_3node_oltp_read_only.pb.gz` which reflects only the allocation during the actual benchmark (excluding the setup/teardown, which can be substantial in tests that spin up in-memory clusters).